### PR TITLE
Fix pull new broken by #306

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1308,7 +1308,7 @@ class IssueCmd (CmdGroup):
                 (title, body) = split_titled_message(msg)
                 title_body['title'] = title
                 title_body['body'] = body
-            cls._do_update(url, args.label, args.assignee,
+            issue = cls._do_update(url, args.labels, args.assignee,
                     args.milestone, args.state, **title_body)
             cls.print_issue_summary(issue)
         @classmethod
@@ -1330,7 +1330,7 @@ class IssueCmd (CmdGroup):
                 params['title'] = title
             if body:
                 params['body'] = body
-            issue = req.patch(url, **params)
+            return req.patch(url, **params)
 
     class CommentCmd (IssueUtil):
         cmd_help = "add a comment to an existing issue"

--- a/git-hub
+++ b/git-hub
@@ -1291,7 +1291,6 @@ class IssueCmd (CmdGroup):
             # through issues to allow changing labels, assignee and
             # milestone (even when GitHub itself doesn't support it
             # :D)
-            url = '/repos/%s/issues/%s' % (config.upstream, args.issue)
             title_body = dict()
             msg = args.message
             title = args.title
@@ -1299,7 +1298,7 @@ class IssueCmd (CmdGroup):
                 title_body['title'] = title
             if args.edit_message:
                 if not msg:
-                    issue = req.get(url)
+                    issue = req.get(cls.url(args.issue))
                     msg = title if title else issue['title']
                     if issue['body']:
                         msg += '\n\n' + issue['body']
@@ -1308,9 +1307,12 @@ class IssueCmd (CmdGroup):
                 (title, body) = split_titled_message(msg)
                 title_body['title'] = title
                 title_body['body'] = body
-            issue = cls._do_update(url, args.labels, args.assignee,
-                    args.milestone, args.state, **title_body)
-            cls.print_issue_summary(issue)
+            issue = cls._do_update(cls.url(args.issue), args.labels,
+                    args.assignee, args.milestone, args.state, **title_body)
+            if issue is None:
+                infof('Nothing to update for #{}', args.issue)
+            else:
+                cls.print_issue_summary(issue)
         @classmethod
         def _do_update(cls, url, labels=None, assignee=None,
                 milestone=None, state=None, title=None, body=None):
@@ -1330,6 +1332,8 @@ class IssueCmd (CmdGroup):
                 params['title'] = title
             if body:
                 params['body'] = body
+            if not params:
+                return None  # Make sure we don't make an invalid empty request
             return req.patch(url, **params)
 
     class CommentCmd (IssueUtil):
@@ -1571,7 +1575,7 @@ class PullCmd (IssueCmd):
             cls.ensure_github_branch_exists(base)
             pull = req.post(cls.url(), head=gh_head, base=base, title=title,
                     body=body, draft=args.draft)
-            IssueCmd.UpdateCmd._do_update(pull['number'], args.labels,
+            IssueCmd.UpdateCmd._do_update(cls.url(pull['number']), args.labels,
                     args.assignee, args.milestone)
             cls.print_issue_summary(pull)
 

--- a/relnotes/issue-304.bug.md
+++ b/relnotes/issue-304.bug.md
@@ -1,5 +1,0 @@
-### Fix `issue update --edit`
-
-A name error was raise when using the command `issue update` with the `--edit` option.
-
-This is a regression introduced in v1.1.0.

--- a/relnotes/issue-update-regressions.bug.md
+++ b/relnotes/issue-update-regressions.bug.md
@@ -1,0 +1,5 @@
+### Fix `issue update` regressions
+
+A name error was raised when using the command `issue update`.
+
+This is a regression introduced in v1.1.0.


### PR DESCRIPTION
When fixing #306, the pull new command was broken as it wasn't adapted
to use the new _do_update().

This is an example traceback shown by pull new:

Pushing v2.x.x to branch in fork
Creating pull request from branch branch to sociomantic-tsunami/git-hub:v2.x.x
Traceback (most recent call last):
  File "./git-hub", line 2254, in <module>
    main()
  File "./git-hub", line 2246, in main
    args.run(parser, args)
  File "./git-hub", line 683, in check_config_and_run
    cmd.run(parser, args)
  File "./git-hub", line 1574, in run
    IssueCmd.UpdateCmd._do_update(pull['number'], args.labels,
  File "./git-hub", line 1333, in _do_update
    return req.patch(url, **params)
  File "./git-hub", line 525, in <lambda>
    self.json_req(url, method, media_type, *args, **kwargs)
  File "./git-hub", line 490, in json_req
    url = self.base_url + url
TypeError: can only concatenate str (not "int") to str